### PR TITLE
Add Upcoming talks section and tidy README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,3 @@ Here's an overview of talks and workshops over the years — 75+ appearances acr
 * [Micronaut framework 4.0 release incorporates auto-upgrade with OpenRewrite recipes](https://www.moderne.io/blog/micronaut-framework-4-0-automated-upgrade-with-openrewrite)
 * [How Axon Framework handles breaking changes through OpenRewrite](https://www.moderne.io/blog/how-axon-framework-handles-breaking-changes-through-openrewrite) 
 * [JDriven blog posts](https://blog.jdriven.com/author/tim-te-beek/)
-
-### Mentions
-* [Spring Cloud Gateway with OpenID Connect and Token Relay](https://blog.jdriven.com/2019/11/spring-cloud-gateway-with-openid-connect-and-token-relay/)
-was mentioned on [Twitter by Josh Long](https://twitter.com/starbuxman/status/1193343417910063104), on [This Week in Spring - November 12, 2019](https://spring.io/blog/2019/11/11/this-week-in-spring-november-12-2019) and [Baeldung Java Weekly, Issue 307](https://www.baeldung.com/java-weekly-307).
-* [Reuse Gradle Build Cache on GitLab](https://blog.jdriven.com/2021/11/reuse-gradle-build-cache-on-gitlab/) was mentioned on [the December 2021 Gradle Build Tool newsletter](https://newsletter.gradle.com/2021/12).
-* [Major migrations made easy with OpenRewrite](https://blog.jdriven.com/2022/03/major-migrations-made-easy-with-openrewrite/) was mentioned on [This Week in Spring - April 5th, 2022](https://spring.io/blog/2022/04/05/this-week-in-spring-april-5th-2022), [This Month in Spring - April 2022](https://tanzu.vmware.com/content/blog/this-month-in-spring-april-2022) and [Moderne Press](https://www.moderne.io/press).
-* [Major migrations made easy by Tim te Beek @ Spring I/O 2022](https://www.youtube.com/watch?v=d8xU24x7Jqo) was mentioned on [Björn Wilmsmann's blog](https://bjoernkw.com/2022/07/10/major-migrations-made-easy-by-tim-te-beek-spring-i-o-2022/) and on [Twitter by Adib Saikali](https://twitter.com/asaikali/status/1536499296471752704) and others.
-* [Upgrading to Axon Framework 4.7 - Automated](https://developer.axoniq.io/w/upgrading-to-axon-framework-4.7-automated) features [my contribution of OpenRewrite migration recipes to Axon Framework](https://github.com/AxonFramework/AxonFramework/pull/2597).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ When not at work you'll find me traveling, bouldering, snowboarding, mountainbik
 ## Talks & workshops
 
 Occasionally I get to present at conferences & meetups.
-Here's an overview of talks and workshops over the years.
+Here's an overview of talks and workshops over the years — 75+ appearances across 17 countries since 2018.
+
+### Upcoming
+
+* 🇩🇪 Cologne, [JCON Europe 2026](https://schedule.jcon.one/2026) — _Break your testing habits_ & _Better Assertions with AssertJ_
+* 🇫🇷 Paris, [Devoxx France 2026](https://www.devoxx.fr/) — _Deterministic modernization in an age of AI_
+* 🏴󠁧󠁢󠁥󠁮󠁧󠁿 London, [Devoxx UK 2026](https://www.devoxx.co.uk/) — _Deterministic modernization in an age of AI_ & _Prepare Your Next Spring Boot Migration_
 
 ### [Deterministic modernization in an age of AI](https://www.devoxx.co.uk/talk/?id=21769)
 * 🏴󠁧󠁢󠁥󠁮󠁧󠁿 London, [Devoxx UK 2026](https://www.devoxx.co.uk/talk/?id=21769), 50 minutes
@@ -37,7 +43,7 @@ Here's an overview of talks and workshops over the years.
 ### [Trusting AI to Modernize Software at Scale](https://sessionize.com/s/timtebeek/trusting-ai-to-modernize-software-at-scale/134366)
 * 🇳🇱 Amsterdam, [ML Ops Community x Uber 2025](https://www.meetup.com/nl-nl/uber-tech-events-amsterdam/events/311899658/), 30 minutes
 * 🇨🇭 Basel, [BaselOne 2025](https://baselone.org/en/baselone-home/#schedule), 45 minutes
-* 🇱🇺 Luxembourg [VoxxedDays Luxembourg 2025](https://mobile.devoxx.com/events/voxxedlu2025/talks/3593/details), 50 minutes [📽️](https://www.youtube.com/watch?v=Hxcwu7cpY4k)
+* 🇱🇺 Luxembourg, [VoxxedDays Luxembourg 2025](https://mobile.devoxx.com/events/voxxedlu2025/talks/3593/details), 50 minutes [📽️](https://www.youtube.com/watch?v=Hxcwu7cpY4k)
 * 🇸🇪 Stockholm, [AIfokus 2025](https://www.jfokus.se/ai-fokus/talks/2557), 50 minutes [📽️](https://youtu.be/ezkp0EI7AFo?si=2WHNBgy7p7FNbFdG)
 * 🇳🇱 Utrecht, [Full Stack Conference 2025](https://www.fullstackconference.nl/), 50 minutes
 
@@ -100,19 +106,19 @@ Here's an overview of talks and workshops over the years.
 * 🇳🇱 Utrecht, [JSpring 2023](https://jspring.nl/speakers/tim-te-beek/), 45 minutes [📽️](https://www.youtube.com/watch?v=jOFfCAleUI8)
 * 🇩🇪 Cologne, [JCON Europe 2023](https://jconeurope2023.sched.com/event/1K3zc), 50 minutes [📽️](https://www.youtube.com/watch?v=2KosvX287cE)
 * 🇧🇬 Sofia, [jPrime 2023](https://jprime.io/agenda/155), 50 minutes [📽️](https://youtu.be/4EB8DrvXbVQ)
-* 🏴󠁧󠁢󠁥󠁮󠁧󠁿 London, [Devoxx UK 2023](https://www.devoxx.co.uk/talk/?id=3126),30 minutes, [📽️](https://www.youtube.com/watch?v=Jzgqj1vY2k0)
+* 🏴󠁧󠁢󠁥󠁮󠁧󠁿 London, [Devoxx UK 2023](https://www.devoxx.co.uk/talk/?id=3126), 30 minutes [📽️](https://www.youtube.com/watch?v=Jzgqj1vY2k0)
 * 🇵🇱 Krakow, [GeeCON 2023](https://2023.geecon.org/speakers/info.html?id=796), 50 minutes
-* 🇨🇭 Zürich, [VoxxedDays Zürich 2023](https://voxxeddays.com/zurich/schedule/talk/?id=4509), 20 minutes, [📽️](https://www.youtube.com/watch?v=q-Le1dx2-t8)
+* 🇨🇭 Zürich, [VoxxedDays Zürich 2023](https://voxxeddays.com/zurich/schedule/talk/?id=4509), 20 minutes [📽️](https://www.youtube.com/watch?v=q-Le1dx2-t8)
 * 🇳🇱 Arnhem, [Arnhem JUG February 2023](https://www.meetup.com/arnhemjug/events/290692019/), 30 minutes
 * 🇧🇪 Brussels, [FOSDEM 2023](https://fosdem.org/2023/schedule/event/migrations/), 20 minutes
 * 🇨🇭 Basel, [BaselOne 2022](https://www.baselone.ch/speech.html?id=04AF2172-A549-47BD-8731-79E4CAC3496D), 25 minutes
-* 🇧🇪 Antwerp, [Devoxx Belgium 2022](https://devoxx.be/talk/?id=16776), 30 minutes, [📽️](https://www.youtube.com/watch?v=7fslFKkCkxg)
+* 🇧🇪 Antwerp, [Devoxx Belgium 2022](https://devoxx.be/talk/?id=16776), 30 minutes [📽️](https://www.youtube.com/watch?v=7fslFKkCkxg)
 * 🇲🇦 Agadir, [Devoxx Morocco 2022](https://devoxx.ma/talk/?id=8815), 25 minutes
-* 🇵🇱 Krakow, [Devoxx Poland 2022](https://devoxx.pl/talk-details/?id=2311), 15 minutes, [📽️](https://www.youtube.com/watch?v=rg1TcaHv-24)
-* 🇱🇺 Luxembourg, [VoxxedDays Luxembourg 2022](https://cfp-voxxed-lux.yajug.org/2022/talk/EIY-8151/Major_migrations_made_easy), 15 minutes, [📽️](https://www.youtube.com/watch?v=6qLe-tZ9Kv0)
-* 🇪🇸 Barcelona, [Spring I/O 2022](https://2022.springio.net/sessions/major-migrations-made-easy), 50 minutes, [📽️](https://www.youtube.com/watch?v=d8xU24x7Jqo)
+* 🇵🇱 Krakow, [Devoxx Poland 2022](https://devoxx.pl/talk-details/?id=2311), 15 minutes [📽️](https://www.youtube.com/watch?v=rg1TcaHv-24)
+* 🇱🇺 Luxembourg, [VoxxedDays Luxembourg 2022](https://cfp-voxxed-lux.yajug.org/2022/talk/EIY-8151/Major_migrations_made_easy), 15 minutes [📽️](https://www.youtube.com/watch?v=6qLe-tZ9Kv0)
+* 🇪🇸 Barcelona, [Spring I/O 2022](https://2022.springio.net/sessions/major-migrations-made-easy), 50 minutes [📽️](https://www.youtube.com/watch?v=d8xU24x7Jqo)
 * 🇳🇱 Utrecht, [TEQnation 2022](https://teqnation.com/speakers-2022/), 15 minutes
-* 🇫🇷 Paris, [Devoxx France 2022](https://cfp.devoxx.fr/2022/talk/TPL-7294/Major_migrations_made_easy), 15 minutes, [📽️](https://www.youtube.com/watch?v=r_jFBDTPKSc)
+* 🇫🇷 Paris, [Devoxx France 2022](https://cfp.devoxx.fr/2022/talk/TPL-7294/Major_migrations_made_easy), 15 minutes [📽️](https://www.youtube.com/watch?v=r_jFBDTPKSc)
 
 ### [Choose your own adventure with Spring Security](https://github.com/timtebeek/spring-security-workshop) (workshop)
 * 🇳🇱 Ede, [JFall 2022](https://jfall.nl/timetable-2022/), 180 minutes
@@ -124,8 +130,7 @@ Here's an overview of talks and workshops over the years.
 * 🇪🇸 Barcelona, [Spring I/O 2022](https://2022.springio.net/sessions/choose-your-own-adventure-with-spring-security-workshop), 120 minutes
 
 ### [Document your lousily coupled micro service architecture](https://2021.jfall.nl/speakers-2021/)
-* 🇳🇱 Ede, [JFall 2021](https://2021.jfall.nl/speakers-2021/), 5 minutes,
-  [📽️](https://youtu.be/Y5MfzYjTBX8?t=2142)
+* 🇳🇱 Ede, [JFall 2021](https://2021.jfall.nl/speakers-2021/), 5 minutes [📽️](https://youtu.be/Y5MfzYjTBX8?t=2142)
 
 ### [Getting started with Kafka Streams](https://github.com/jresoort/kafkastreams-workshop) (workshop)
 * 🇪🇸 Barcelona, [Spring I/O 2018](https://2018.springio.net/speakers/tim-te-beek), 120 minutes


### PR DESCRIPTION
## Summary
- Add an **Upcoming** section at the top of Talks & workshops, highlighting JCON Europe 2026, Devoxx France 2026, and Devoxx UK 2026.
- Add a one-line stat to the intro: 75+ appearances across 17 countries since 2018.
- Normalize bullet formatting throughout (fix missing space/extra commas around video links, add missing comma after Luxembourg, collapse the JFall 2021 entry onto a single line).

## Test plan
- [x] Rendered preview of README.md on GitHub looks correct